### PR TITLE
fix(deps): restore pnpm overrides block in lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash: '>=4.18.1'
+
 importers:
 
   .:


### PR DESCRIPTION
## Summary
- Re-adds the `overrides: lodash: '>=4.18.1'` header to `pnpm-lock.yaml`, which Renovate PR #619 silently dropped.
- The mismatch with `package.json`'s `pnpm.overrides` block has been breaking every push to `main` with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` during `pnpm install --frozen-lockfile` (Deploy to GitHub Pages job).
- Regenerated via `pnpm install --lockfile-only` — only 3 lines added, no dependency versions changed.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds locally
- [x] Pre-commit hooks (format, eslint, stylelint, knip, cspell, typecheck) all pass
- [ ] CI `Deploy to GitHub Pages` workflow goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)