### PR TITLE
fix(tests): restore green e2e suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"lint:styles:fix": "pnpm run lint:styles:check --fix",
 		"preview": "astro preview",
 		"tsc": "tsc",
-		"test": "playwright test e2e/tests/",
+		"test": "run-s test:e2e:*",
 		"test:e2e": "run-s test:e2e:*",
 		"test:e2e:accessibility": "playwright test e2e/tests/accessibility",
 		"test:e2e:pages": "playwright test e2e/tests/pages",

--- a/src/components/resume-button.astro
+++ b/src/components/resume-button.astro
@@ -23,8 +23,8 @@
 		position: relative;
 		top: 1.5px;
 		display: inline;
-		border-bottom: 2px solid var(--color-primary);
-		color: var(--color-primary);
+		border-bottom: 2px solid oklch(48% 0.13 159.37deg);
+		color: oklch(48% 0.13 159.37deg);
 	}
 
 	.resume-button {

--- a/src/lib/section-card-scroll-animation.ts
+++ b/src/lib/section-card-scroll-animation.ts
@@ -38,8 +38,8 @@ export default class SectionCardScrollAnimation {
 				autoAlpha: 0,
 				scrollTrigger: {
 					trigger: $el,
-					start: `bottom bottom+=${$card?.offsetHeight}`,
-					end: `+=${window.innerHeight}`,
+					start: () => `bottom bottom+=${window.innerHeight}`,
+					end: () => `+=${window.innerHeight}`,
 					scrub: true,
 					invalidateOnRefresh: true,
 					onToggle: (self) => {


### PR DESCRIPTION
## Summary

Both `pnpm test` and `pnpm test:e2e` were red. Failures came from two real bugs (not stale assertions) plus a script-level contention problem with the Lighthouse audit. All three are fixed and both commands now finish green.

- **`#me` color contrast (`src/components/resume-button.astro`)** — the "ME" span inherited `--color-primary` (`oklch(77% 0.17 159.37deg)` ≈ `#20d48c`), giving a 1.56:1 contrast against the `bg-gray-200` parent. Darkened to `oklch(48% 0.13 159.37deg)` to clear WCAG AA 4.5:1.
- **Scroll-card animation start position (`src/lib/section-card-scroll-animation.ts`)** — ScrollTrigger used `bottom bottom+=${$card.offsetHeight}`. When the card content overflowed the viewport (e.g. Pixel 5: card 1143 px > viewport 727 px), this computed a negative start position, so at scroll 0 the header was already ~57% faded. That produced a real a11y contrast failure for mobile users (`bg-gray-200` rendering as ~`#434445` over the black body) and was the root cause of the mobile-chrome axe violation. Replaced with `window.innerHeight` and wrapped both `start`/`end` in functions so values recompute on `invalidateOnRefresh`.
- **`pnpm test` parallel-contention with Lighthouse (`package.json`)** — `playwright test e2e/tests/` ran the Lighthouse audit in parallel with 7 other browser tests. Score collapsed to 64 under load (95+ when isolated). Aligned `pnpm test` with `pnpm test:e2e` (`run-s test:e2e:*`) so each suite runs in turn — Lighthouse now consistently scores 92–96, above the 90 threshold.

## Test plan

- [x] `pnpm test` — 8 + 8 + 3 passed, 16 visual skipped (already-skipped golden-screenshot suite, untouched)
- [x] `pnpm test:e2e` — same result; Lighthouse 92–96
- [x] `pnpm types:check` — 0 errors / 0 warnings / 0 hints
- [x] `pnpm exec prettier --check` on changed files — clean
- [x] `pnpm exec eslint` on changed files — clean
- [x] Pre-push hooks (typecheck, dead-code, spelling-full, dedupe) — green

## Out of scope

- Re-enabling the four currently-`.skip()`'d visual regression tests.
- A separate unit-test runner (no `*.test.ts` files are executed by any runner today; the only `src/config/animation.test.ts` is a typecheck-only validation file).
- Unrelated pre-existing format issue in `.claude/settings.local.json` (a gitignored Claude internal file Prettier still scans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)