### PR TITLE
feat(home): drench hero fold in Signal Mint

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -168,7 +168,7 @@ A handful of RGB literals live inside signature-motion components and are outsid
 
 **The Gallery-Wall Rule.** The black canvas is never a text surface. Every piece of body copy sits on a card. If you find yourself setting readable text directly on black, you are decorating the wall — stop.
 
-**The One-Voice-Per-Section Rule.** Each card commits to one accent. Signal Mint OR Cobalt Draft OR off-white — never two competing on the same surface. The About section commits to Signal Mint end-to-end (Bio identity + Contact action); the section itself is one voice, and the map plate is neutral by nature. Lavender Wash is now unused after the testimonials tile was folded into Bio — leave it in the token file for future use rather than the current site.
+**The One-Voice-Per-Section Rule.** Each card commits to one accent. Signal Mint OR Cobalt Draft OR off-white — never two competing on the same surface. The hero fold and the About section both commit to Signal Mint — hero as a drenched field with an off-white card floating on it (see Cards / Containers → Field vs. plate below), About as mint plates (Bio + Contact) with a neutral map. The mint field bookends the page; projects and the mystery-box footer sit on the black canvas between. Lavender Wash is now unused after the testimonials tile was folded into Bio — leave it in the token file for future use rather than the current site.
 
 **The Signature-Motion Isolation Rule.** The signature-motion palette (Mystery-Box gradient, Resume-button hover bubbles) is component-scoped. Do not pull those RGB literals into new components. If you need a new signature moment, propose a new named literal for it and add it here.
 
@@ -232,6 +232,7 @@ Five tiers, ordered by weight. Every clickable element on the site belongs to ex
 
 - **Corner Style:** `16px` on the card baseline, `24px` on the About-grid plates (larger surfaces earn a larger radius).
 - **Background:** Signal Mint (Bio identity + Contact panel), Card Off-White (hero card, Location plate, default). Never on black. See the One-Voice-Per-Section rule above; About section commits to Signal Mint end-to-end.
+- **Field vs. plate:** The hero section is _drenched_ — its section wrapper is Signal Mint so the fold opens on brand color, and the off-white hero card floats on the mint field. Card-on-mint framing lets the palette land in second 0 without abandoning the light-plate reading model. Only the hero fold uses this layering; project slabs and About tiles remain flat.
 - **Shadow Strategy:** None at rest. See Elevation.
 - **Border:** None. Contrast carries the edge.
 - **Internal Padding:** `1rem` → `3rem` fluid; the plate breathes.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE='cache-1783709723137-dev';
+const CACHE='cache-1783710451731-dev';
 const ASSETS=[];
 
 /*

--- a/src/components/landing.astro
+++ b/src/components/landing.astro
@@ -11,7 +11,7 @@ const projects = await getCollection('project');
 <section
 	id="header"
 	aria-labelledby="header-headline"
-	class="js-section-card-wrapper relative -mb-[100vh] h-[250vh]"
+	class="js-section-card-wrapper bg-primary relative -mb-[100vh] h-[250vh]"
 >
 	<div
 		class="js-section-card h-full-mobile sticky top-0 flex min-h-screen w-full overflow-hidden p-4 sm:p-8 lg:p-6"


### PR DESCRIPTION
## Summary

Addresses **P1 mint-the-fold** from the `/impeccable critique` backlog (round two): the hero was opening on a neutral off-white card while DESIGN.md declared Signal Mint as the register-carrier. Palette-is-voice was arriving three folds late.

- **`src/components/landing.astro`** — added `bg-primary` to the hero `<section>` wrapper. The `#header-content-wrapper` card stays `bg-base-100` (off-white), so the fold now shows a Signal Mint field with an off-white card floating on it. Sticky-scale scroll mechanic unchanged.
- **`DESIGN.md`** — documented the pattern:
  - Cards / Containers section: new **Field vs. plate** bullet naming the drenched-hero layering.
  - One-Voice-Per-Section rule: extended to describe the mint bookends (hero fold + About) framing the black canvas between.

## Design behavior

- **Second 0:** Signal Mint lands immediately. Brand palette arrives before any scroll.
- **Scroll transition:** the mint field is on the outer wrapper, so it stays put while the sticky-scale animation zooms/fades the off-white card. Next section's `-mb-[100vh]` pulls project 1 up to overlap.
- **Page rhythm:** mint fold → 4 dark project slabs → mint About section → black canvas footer with mystery box. Light/dark bookends.
- **Contrast unchanged.** All hero interactive elements (H1 in black on off-white, Let's Talk black circle, Resume pill, social icons) live INSIDE the off-white card. No new contrast risk on the mint field.

## Test plan

- [x] `pnpm types:check` — 0 errors
- [x] `pnpm build` — 4 pages built successfully
- [x] `pnpm exec playwright test e2e/tests/accessibility e2e/tests/pages/index.spec.ts` — **16/16 pass**
- [x] Pre-push lefthook checks (dead-code, spelling-full, dedupe, typecheck) — all green
- [ ] Visual iteration owed: the mint→black transition as the card scales out is best confirmed in browser. If it feels harsh, we can add a mint→black gradient at the bottom of the hero wrapper OR ease the fade timing on the sticky-scale animation.