### PR TITLE
fix(ci): restore prettier compliance to unblock Pages deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ stats.html
 
 # impeccable design tooling — user-local skill and generated caches
 .claude/skills/
+.claude/settings.local.json
 .impeccable/config.local.json
 .impeccable/hook.cache.json
 .impeccable/live/
+
+# lint caches
+.eslintcache

--- a/src/components/contact.astro
+++ b/src/components/contact.astro
@@ -21,13 +21,13 @@ import { CONTACT_EMAIL, CONTACT_MAILTO_HREF } from '@/utils/email.server';
 
 	<div class="relative z-10">
 		<h3
-			class="contact-button-title mb-6 !font-extrabold !leading-[0.9] uppercase !text-6xl sm:!text-7xl lg:!text-6xl xl:!text-7xl"
+			class="contact-button-title mb-6 !text-6xl !leading-[0.9] !font-extrabold uppercase sm:!text-7xl lg:!text-6xl xl:!text-7xl"
 		>
 			Let’s build<br />something.
 		</h3>
 		<p
 			id="email-text"
-			class="js-inject-email-text contact-button-email mb-0 font-sans text-lg font-medium !leading-tight sm:text-xl lg:text-lg"
+			class="js-inject-email-text contact-button-email mb-0 font-sans text-lg !leading-tight font-medium sm:text-xl lg:text-lg"
 		>
 			{CONTACT_EMAIL}
 		</p>

--- a/src/lib/scrub-controlled-lottie.ts
+++ b/src/lib/scrub-controlled-lottie.ts
@@ -82,7 +82,7 @@ export default class ScrubControlledAnimation {
 
 		let triggerTarget = null;
 		if (target > 0) {
-			for (let i = target; i--; ) {
+			for (let i = target; i--;) {
 				triggerTarget = container.parentElement;
 			}
 		}


### PR DESCRIPTION
## Summary

The most recent \`Deploy to GitHub Pages\` run (#29136098352) failed on the \`format:check\` step. Two files had drifted after recent tailwindcss + prettier version bumps landed on main via dependency-update PRs:

- **\`src/components/contact.astro\`** — \`prettier-plugin-tailwindcss\` reordered a few utility classes on the contact-button heading and email row (e.g. \`!font-extrabold !leading-[0.9] uppercase !text-6xl\` → \`!text-6xl !leading-[0.9] !font-extrabold uppercase\`). No semantic change; just canonical Tailwind sort order.
- **\`src/lib/scrub-controlled-lottie.ts\`** — a for-loop with an empty init lost its trailing space before the closing paren (\`for (let i = target; i--; )\` → \`for (let i = target; i--;)\`). Prettier 3.9 changed this rule.

Neither file was in the staged set of recent PRs, so lefthook's per-file pre-commit prettier run didn't catch the drift. CI runs \`format:check\` across the whole tree, which is what caught it.

## Also

- Adds \`.claude/settings.local.json\` and \`.eslintcache\` to \`.gitignore\` — both are user-local machine-generated files that were leaking into local prettier warnings.

## Test plan

- [x] \`pnpm format:check\` locally — passes (matches CI)
- [x] Pre-push hooks (dead-code, spelling-full, dedupe, typecheck) — all green
- [ ] After merge: confirm the next Pages deploy workflow run goes green